### PR TITLE
A simpler base

### DIFF
--- a/test/bifrost/core_test.clj
+++ b/test/bifrost/core_test.clj
@@ -53,8 +53,9 @@
           request {:request-method :get
                    :bifrost-params {:test true}}
           ctx {:request request}
-          _ (enter ctx)
-          otherwise-created-ctx {:response {:status :201 :body "Handled by someone else"}}]
+          middle-ctx (enter ctx)
+          otherwise-created-ctx (merge middle-ctx
+                                       {:response {:status :201 :body "Handled by someone else"}})]
       (let [[response-ch request] (async/<!! closed-test-ch)]
         (async/close! response-ch)
         (let [final-ctx (leave otherwise-created-ctx)]


### PR DESCRIPTION
`async-interceptor` is reduced to fewer assumptions. It deals only in full pedestal contexts, and waits to take from the response channel until its leave function.

We lose the niceness of the `IntoInterceptor` protocol, but the `interceptor` provides different niceities: the response channel is added to the context during the enter function, so further interceptors may use it if needed.
