### PR TITLE
only put the params-map on the request chan

### DIFF
--- a/src/bifrost/core.clj
+++ b/src/bifrost/core.clj
@@ -39,8 +39,7 @@
                                (:bifrost-params request))))
 
 (defn ctx->bifrost-request [ctx]
-  (let [request (:request ctx)]
-    (assoc request :bifrost-params (params-map request))))
+  (params-map (:request ctx)))
 
 (def interceptor-xf
   (map (fn [[response-ch ctx]]


### PR DESCRIPTION
The whole request is only partially serializeable (though not every consumer will need that) and contains lots of HTTP-specific things that you wouldn't want to couple to whatever's on the other end of your channels.
