### PR TITLE
Allow setting timeouts for each interceptor

### DIFF
--- a/src/bifrost/core.clj
+++ b/src/bifrost/core.clj
@@ -3,7 +3,7 @@
             [clojure.core.async :as async]
             [ring.util.response :as ring-resp]))
 
-(def ^:dynamic *response-timeout* 10000)
+(def default-timeout 10000)
 
 (defn error-response->http-status
   [error-response]
@@ -61,6 +61,11 @@
   ([channel response-channel-key]
    (async-interceptor channel response-channel-key (map identity)))
   ([channel response-channel-key response-channel-xf]
+   (async-interceptor channel
+                      response-channel-key
+                      (map identity)
+                      default-timeout))
+  ([channel response-channel-key response-channel-xf timeout]
    (interceptor/interceptor
     {:enter
      (fn [ctx]
@@ -70,14 +75,22 @@
      :leave
      (fn [ctx]
        (if-let [response (async/alt!!
-                           (async/timeout *response-timeout*) {:response {:status 504 :body "Timeout"}}
-                           (get-in ctx [:response-channels response-channel-key]) ([r] r))]
+                           (async/timeout timeout)
+                           {:response {:status 504
+                                       :body "Bifrost timeout"}}
+
+                           (get-in ctx [:response-channels response-channel-key])
+                           ([r] r))]
          (merge ctx response)
          ctx))})))
 
 (defmacro interceptor
-  [channel]
-  (let [response-channel-key (keyword channel)]
-    `(let [request-ch# (async/chan 1 interceptor-xf)]
-       (async/pipe request-ch# ~channel)
-       (async-interceptor request-ch# ~response-channel-key api-response-xf))))
+  ([channel] `(interceptor ~channel ~default-timeout))
+  ([channel timeout]
+   (let [response-channel-key (keyword channel)]
+     `(let [request-ch# (async/chan 1 interceptor-xf)]
+        (async/pipe request-ch# ~channel)
+        (async-interceptor request-ch#
+                           ~response-channel-key
+                           api-response-xf
+                           ~timeout)))))

--- a/test/bifrost/core_test.clj
+++ b/test/bifrost/core_test.clj
@@ -45,7 +45,7 @@
       (let [[response-ch request] (async/<!! timeout-test-ch)]
         (let [final-ctx (leave middle-ctx)]
           (is (= 504 (get-in final-ctx [:response :status])))
-          (is (= "Timeout" (get-in final-ctx [:response :body])))))))
+          (is (= "Bifrost timeout" (get-in final-ctx [:response :body])))))))
   (testing "will forward the ctx through if the response channel has been closed"
     (let [closed-test-ch (async/chan)
           async-interceptor (interceptor closed-test-ch)


### PR DESCRIPTION
We were running into the hard-coded 10 second timeout tripping us up
when testing some upstream timeout behavior. Obviously we'd never
tolerate timeouts this long in production, but we were trying to get a
successful fallback response by setting the HTTP API gateway timeout
higher and weren't able to go above 10 seconds because of this.

This now allows optionally setting the timeout when you create a bifrost
interceptor and makes it clear that the timeout is coming from bifrost
in the response body when it occurs.
