### PR TITLE
Make bifrost use async fns.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,20 @@
 # Change Log
 
+## Changes between 0.1.5 and HEAD
+
+**This is a breaking change.**
+
+* Change `bifrost.core/interceptor` to work with functions that return
+  core.async channels. This makes it less dependent on Kehaar's
+  message format. To change existing interceptors, replace the
+  channels passed as arguments with either functions returned by
+  `kehaar.wire-up/async->fn` or
+  `kehaar.power/defn-external-service`.
+* Removed `bifrost.core/interceptor-xf`,
+  `bifrost.core/api-response-xf`, and
+  `bifrost.core/async-interceptor`.
+* Converted `bifrost.core/interceptor` from a macro to a function.
+
 ## Changes between 0.1.4 and 0.1.5
 
 * Added a new optional argument to `bifrost.core/interceptor` and

--- a/src/bifrost/core.clj
+++ b/src/bifrost/core.clj
@@ -43,11 +43,13 @@
 
 (defn api-response->ctx
   [api-response]
-  (let [status (response->http-status api-response)]
-    {:response (-> api-response
-                   (dissoc :status)
-                   ring-resp/response
-                   (ring-resp/status status))}))
+  (if (nil? api-response)
+    {:response {:status :201, :body "Handled by someone else"}}
+    (let [status (response->http-status api-response)]
+      {:response (-> api-response
+                     (dissoc :status)
+                     ring-resp/response
+                     (ring-resp/status status))})))
 
 (defn interceptor
   ([f]

--- a/src/bifrost/core.clj
+++ b/src/bifrost/core.clj
@@ -49,13 +49,13 @@
                    ring-resp/response
                    (ring-resp/status status))}))
 
-(defn async-interceptor
+(defn interceptor
   ([f]
-   (async-interceptor f (gensym)))
+   (interceptor f (gensym)))
   ([f response-channel-key]
-   (async-interceptor f
-                      response-channel-key
-                      default-timeout))
+   (interceptor f
+                response-channel-key
+                default-timeout))
   ([f response-channel-key timeout]
    (interceptor/interceptor
     {:enter


### PR DESCRIPTION
Async fns are fns that return a channel that will have the response. This now depends less on Kehaar. It was never an explicit dependency, but it did rely on using the same message format as Kehaar (`[response-channel message]`). Now it works with any function of one argument (the message) that returns a channel that will have the response on it.
