### PR TITLE
More response types

### DIFF
--- a/src/bifrost/core.clj
+++ b/src/bifrost/core.clj
@@ -20,7 +20,7 @@
 (defn response->http-status
   [response]
   (case (:status response)
-    :ok 200
+    (:ok :duplicate) 200
     :created 201
     :error (error-response->http-status (:error response))
     500))

--- a/src/bifrost/core.clj
+++ b/src/bifrost/core.clj
@@ -1,8 +1,7 @@
 (ns bifrost.core
   (:require [io.pedestal.interceptor :as interceptor]
             [clojure.core.async :as async]
-            [ring.util.response :as ring-resp]
-            [io.pedestal.log :as log]))
+            [ring.util.response :as ring-resp]))
 
 (def default-timeout 10000)
 

--- a/src/bifrost/core.clj
+++ b/src/bifrost/core.clj
@@ -1,12 +1,14 @@
 (ns bifrost.core
   (:require [io.pedestal.interceptor :as interceptor]
             [clojure.core.async :as async]
-            [ring.util.response :as ring-resp]))
+            [ring.util.response :as ring-resp]
+            [io.pedestal.log :as log]))
 
 (def default-timeout 10000)
 
 (defn error-response->http-status
   [error-response]
+  (log/debug "bifrost error response:" (pr-str error-response))
   (case (:type error-response)
     :semantic 400
     :validation 400

--- a/src/bifrost/core.clj
+++ b/src/bifrost/core.clj
@@ -11,6 +11,7 @@
     :semantic 400
     :validation 400
     :not-found 404
+    :conflict 409
     :server 500
     :timeout 504
     500))

--- a/src/bifrost/core.clj
+++ b/src/bifrost/core.clj
@@ -8,7 +8,6 @@
 
 (defn error-response->http-status
   [error-response]
-  (log/debug "bifrost error response:" (pr-str error-response))
   (case (:type error-response)
     :semantic 400
     :validation 400
@@ -50,7 +49,6 @@
 
 (defn api-response->ctx
   [api-response]
-  (log/debug "bifrost got response:" (pr-str api-response))
   (let [status (response->http-status api-response)]
     {:response (-> api-response
                    (dissoc :status)

--- a/src/bifrost/core.clj
+++ b/src/bifrost/core.clj
@@ -50,6 +50,7 @@
 
 (defn api-response->ctx
   [api-response]
+  (log/debug "bifrost got response:" (pr-str api-response))
   (let [status (response->http-status api-response)]
     {:response (-> api-response
                    (dissoc :status)

--- a/src/bifrost/core.clj
+++ b/src/bifrost/core.clj
@@ -66,7 +66,7 @@
   ([channel response-channel-key response-channel-xf]
    (async-interceptor channel
                       response-channel-key
-                      (map identity)
+                      response-channel-xf
                       default-timeout))
   ([channel response-channel-key response-channel-xf timeout]
    (interceptor/interceptor


### PR DESCRIPTION
[Pivotal card](https://www.pivotaltracker.com/story/show/144867263)

This is to better support "this user already exists" responses for TV Classic user imports. I started with `409 Conflict` responses (so that's why that is added in here), but then realized in this context it shouldn't be an error. We're sending lots of user create requests fully anticipating that some will already exist and should be left alone. So that's just a different success scenario. That's how I ended up with a `200 OK` for the `:duplicate` status.

This has been tested in krakenstein with TV Classic user imports.