### PR TITLE
bifrost interceptor can take a function, isn't a macro

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Changes between 0.1.5 and HEAD
+
+* `bifrost.core/interceptor` is no longer a macro.
+* The first argument `bifrost.core/interceptor`, instead of being an
+  async channel, may be a function that will called with the bifrost
+  request and returns a core async channel that the result will
+  eventually be placed on.
+
 ## Changes between 0.1.4 and 0.1.5
 
 * Added a new optional argument to `bifrost.core/interceptor` and

--- a/test/bifrost/core_test.clj
+++ b/test/bifrost/core_test.clj
@@ -3,13 +3,13 @@
             [bifrost.core :refer :all]
             [clojure.core.async :as async]))
 
-(deftest interceptor-test
+(deftest interceptor-with-async-chan-test
   (testing "adds a key to the context where the response channel is"
     (let [key-test-ch (async/chan)
           async-interceptor (interceptor key-test-ch)
           enter (:enter async-interceptor)
           out-ctx (enter {:request {:request-method :get}})]
-      (is (get-in out-ctx [:response-channels :key-test-ch]))))
+      (is (= 1 (count (:response-channels out-ctx))))))
   (testing "puts just the bifrosted request onto the request part of the channel"
     (let [request-only-test-ch (async/chan)
           async-interceptor (interceptor request-only-test-ch)
@@ -60,6 +60,68 @@
         (async/close! response-ch)
         (let [final-ctx (leave otherwise-created-ctx)]
           (is (= final-ctx otherwise-created-ctx)))))))
+
+(deftest interceptor-with-fn-test
+  (let [fn-with-response (fn [_]
+                           (async/go
+                             {:status :ok
+                              :bridge-endpoints #{"Midgard" "Asgard"}}))
+        async-identity (fn [arg]
+                         (async/go arg))
+        fn-timeout (fn [_]
+                     (async/chan))
+        fn-closed-chan (fn [_]
+                         (let [c (async/chan)]
+                           ;; fake a situation where the function
+                           ;; closes the channel if it knows there's
+                           ;; nothing worth doing
+                           (async/close! c)
+                           c))]
+    (testing "adds a key to the context where the response channel is"
+      (let [fn-interceptor (interceptor fn-with-response)
+            enter (:enter fn-interceptor)
+            out-ctx (enter {:request {:request-method :get}})]
+        (is (= 1 (count (:response-channels out-ctx))))))
+    (testing "calls the function with just the bifrosted request"
+      (let [async-interceptor (interceptor async-identity)
+            enter (:enter async-interceptor)
+            request {:request-method :get
+                     :query-params {:test true}}
+            ctx {:request request}
+            out-ctx (enter ctx)]
+        (let [chan (-> out-ctx :response-channels vals first)
+              bifrost-request (async/<!! chan)]
+          (is (= bifrost-request
+                 (ctx->bifrost-request ctx))))))
+    (testing "takes a API-like response from the channel the function returns and puts a Ring-like response on the ctx"
+      (let [{:keys [enter leave]} (interceptor fn-with-response)
+            request {:request-method :get
+                     :bifrost-params {:test true}}
+            ctx {:request request}
+            out-ctx (leave (enter ctx))]
+        (is (= 200 (get-in out-ctx [:response :status])))
+        (is (= {:bridge-endpoints #{"Midgard" "Asgard"}}
+               (get-in out-ctx [:response :body])))))
+    (testing "will respond with a timeout if nothing happens on the channel returned by the function"
+      (let [{:keys [enter leave]} (interceptor fn-timeout)
+            request {:request-method :get
+                     :bifrost-params {:test true}}
+            ctx {:request request}
+            out-ctx (leave (enter ctx))]
+        (is (= 504 (get-in out-ctx [:response :status])))
+        (is (= "Bifrost timeout" (get-in out-ctx [:response :body])))))
+    (testing "will forward the ctx through if the channel returned by the function has been closed"
+      (let [{:keys [enter leave]} (interceptor fn-closed-chan)
+            request {:request-method :get
+                     :bifrost-params {:test true}}
+            ctx {:request request}
+            middle-ctx (enter ctx)
+            otherwise-created-ctx (merge middle-ctx
+                                         {:response
+                                          {:status :201
+                                           :body "Handled by someone else"}})
+            out-ctx (leave otherwise-created-ctx)]
+        (is (= out-ctx otherwise-created-ctx))))))
 
 (deftest params-map-test
   (testing "GET/DELETE merges bifrost-params -> path-params -> query-params"


### PR DESCRIPTION
* `bifrost.core/interceptor` is no longer a macro.
* The first argument `bifrost.core/interceptor`, instead of being an async channel, _may_ be a function that will be called with the bifrost request and returns a core async channel that the result will eventually be placed on.

Replaces #4