### PR TITLE
Add `bifrost.core/handler`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Changes between 0.2.0 and 0.3.0
+
+* **[Breaking]**: removed the lower-level `bifrost.core/async-interceptor`
+  function.
+* Added a new `bifrost.core/handler` function that works like
+  `bifrost.core/interceptor`, but assocs an error response if the channel is
+  already closed.
+
 ## Changes between 0.1.5 and 0.2.0
 
 * `bifrost.core/interceptor` is no longer a macro.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ transform the response into a context with a response and merge it
 with the incoming context. If it cannot take from the response channel
 within the timeout, it will create a 504 response.
 
+For interceptors that should have exclusive access to the response channel, use
+`handler` instead, which assocs a 500 response when the response channel closes
+unexpectedly.
+
 Bifrost requests are Pedestal requests with the following changes:
 
 * On GET and DELETE

--- a/README.md
+++ b/README.md
@@ -127,10 +127,6 @@ the `[:request :bifrost-params]` key path in the context.
 Bifrost will then merge the `:bifrost-params` value into everything
 else so those keys will clobber the others in the final `params-map`.
 
-The `async-interceptor` function is available if you want more control
-over what happens to the messages sent and consumed by the
-interceptor.
-
 ### Update Interceptors
 
 The `bifrost.interceptors` namespace includes some handy interceptors for

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject democracyworks/bifrost "0.2.1-SNAPSHOT"
+(defproject democracyworks/bifrost "0.3.0-SNAPSHOT"
   :description "Library for writing HTTP API gateways with Pedestal & core.async"
   :url "https://github.com/democracyworks/bifrost"
   :license {:name "Mozilla Public License"

--- a/test/bifrost/core_test.clj
+++ b/test/bifrost/core_test.clj
@@ -123,6 +123,64 @@
             out-ctx (leave otherwise-created-ctx)]
         (is (= out-ctx otherwise-created-ctx))))))
 
+(deftest handler-with-fn-test
+  (let [fn-with-response (fn [_]
+                           (async/go
+                             {:status :ok
+                              :bridge-endpoints #{"Midgard" "Asgard"}}))
+        async-identity (fn [arg]
+                         (async/go arg))
+        fn-timeout (fn [_]
+                     (async/chan))
+        fn-closed-chan (fn [_]
+                         (let [c (async/chan)]
+                           ;; fake a situation where the function
+                           ;; closes the channel if it knows there's
+                           ;; nothing worth doing
+                           (async/close! c)
+                           c))]
+    (testing "adds a key to the context where the response channel is"
+      (let [fn-interceptor (handler fn-with-response)
+            enter (:enter fn-interceptor)
+            out-ctx (enter {:request {:request-method :get}})]
+        (is (= 1 (count (:response-channels out-ctx))))))
+    (testing "calls the function with just the bifrosted request"
+      (let [async-interceptor (handler async-identity)
+            enter (:enter async-interceptor)
+            request {:request-method :get
+                     :query-params {:test true}}
+            ctx {:request request}
+            out-ctx (enter ctx)]
+        (let [chan (-> out-ctx :response-channels vals first)
+              bifrost-request (async/<!! chan)]
+          (is (= bifrost-request
+                 (ctx->bifrost-request ctx))))))
+    (testing "takes a API-like response from the channel the function returns and puts a Ring-like response on the ctx"
+      (let [{:keys [enter leave]} (handler fn-with-response)
+            request {:request-method :get
+                     :bifrost-params {:test true}}
+            ctx {:request request}
+            out-ctx (leave (enter ctx))]
+        (is (= 200 (get-in out-ctx [:response :status])))
+        (is (= {:bridge-endpoints #{"Midgard" "Asgard"}}
+               (get-in out-ctx [:response :body])))))
+    (testing "will respond with a timeout if nothing happens on the channel returned by the function"
+      (let [{:keys [enter leave]} (handler fn-timeout)
+            request {:request-method :get
+                     :bifrost-params {:test true}}
+            ctx {:request request}
+            out-ctx (leave (enter ctx))]
+        (is (= 504 (get-in out-ctx [:response :status])))
+        (is (= "Bifrost timeout" (get-in out-ctx [:response :body])))))
+    (testing "will respond with a closed channel response if the channel returned by the function has been closed"
+      (let [{:keys [enter leave]} (handler fn-closed-chan)
+            request {:request-method :get
+                     :bifrost-params {:test true}}
+            ctx {:request request}
+            out-ctx (leave (enter ctx))]
+        (is (= 500 (get-in out-ctx [:response :status])))
+        (is (= "Channel was closed unexpectedly" (get-in out-ctx [:response :body])))))))
+
 (deftest params-map-test
   (testing "GET/DELETE merges bifrost-params -> path-params -> query-params"
     (are [request-method]


### PR DESCRIPTION
`handler` is the same as `interceptor`, but it expects exclusive access to the response channel, so it assocs an error response if the channel is closed when it tries to take from it. I would have just made that the default, but the "ignore closed channels" bit is documented in the readme, so rather than break existing users I added a new function that hopefully expresses the difference and justifies itself as a new function.

I swear I didn't mean to change this many lines when I started, but in the end parts of this felt ripe for a refactor and I got a little carried away 🤷‍♂ Happy to go back to a more conservative changeset if you think that's more appropriate. I ended up removing a documented function (`async-interceptor`, which I wasn't able to find any uses of in our code), so I bumped the minor version rather than the patch.

